### PR TITLE
Qt6

### DIFF
--- a/de.shorsh.discord-screenaudio.yml
+++ b/de.shorsh.discord-screenaudio.yml
@@ -1,9 +1,9 @@
 app-id: de.shorsh.discord-screenaudio
 runtime: org.kde.Platform
-runtime-version: "5.15-22.08"
+runtime-version: "6.5"
 sdk: org.kde.Sdk
 base: io.qt.qtwebengine.BaseApp
-base-version: "5.15-22.08"
+base-version: "6.5"
 command: discord-screenaudio
 finish-args:
   - --share=ipc
@@ -29,5 +29,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/maltejur/discord-screenaudio.git
-        tag: v1.8.2
-        commit: 3f9d21cc86776d28509328394043038dcf7b7b26
+        commit: 0979de2eae14b80b40372fd3c953d0917d4eb6bc


### PR DESCRIPTION
Currently, KDE Frameworks do not work yet with Qt6